### PR TITLE
Add optional strategy pattern skeleton for future writing handling

### DIFF
--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
@@ -70,6 +70,19 @@ def _post_method(url, headers, data, operation_description):
         _log.error(err)
         raise Exception(err)
 
+class WriteStrategy:
+    def execute(self, interface, register, value):
+        raise NotImplementedError()
+
+
+class SwitchWriteStrategy(WriteStrategy):
+    def execute(self, interface, register, value):
+        raise NotImplementedError()
+
+
+class CoverWriteStrategy(WriteStrategy):
+    def execute(self, interface, register, value):
+        raise NotImplementedError()
 
 class Interface(BasicRevert, BaseInterface):
     def __init__(self, **kwargs):
@@ -79,6 +92,10 @@ class Interface(BasicRevert, BaseInterface):
         self.access_token = None
         self.port = None
         self.units = None
+        self.write_strategies = {
+            "switch": SwitchWriteStrategy(),
+            "cover": CoverWriteStrategy(),
+        }
 
     def configure(self, config_dict, registry_config_str):
         self.ip_address = config_dict.get("ip_address", None)


### PR DESCRIPTION
This PR introduces a lightweight Strategy Pattern skeleton for potential future handling of domain-specific write operations.

The purpose is to demonstrate a possible modular architecture without modifying existing driver logic.

Changes include:
- Adding WriteStrategy base class
- Adding SwitchWriteStrategy example
- Adding CoverWriteStrategy example

Important:
This change does NOT modify current execution paths (e.g., `_set_point`) and does not affect existing functionality.

These classes act only as a design demonstration and optional future extension point.