### PR TITLE
Add switch handler with read/write support and tests

### DIFF
--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/api_client.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/api_client.py
@@ -1,0 +1,51 @@
+import logging
+import requests
+
+_log = logging.getLogger(__name__)
+
+
+class HomeAssistantAPIClient:
+    """
+    Thin HTTP wrapper for the Home Assistant REST API.
+    Only two public methods: get_state() and call_service().
+    """
+
+    def __init__(self, ip_address, port, access_token):
+        self.base_url = f"http://{ip_address}:{port}"
+        self.headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        }
+
+    def get_state(self, entity_id):
+        """GET /api/states/{entity_id} → returns full entity JSON"""
+        url = f"{self.base_url}/api/states/{entity_id}"
+        response = requests.get(url, headers=self.headers)
+        if response.status_code == 200:
+            return response.json()
+        else:
+            error_msg = (
+                f"GET {url} failed with status {response.status_code}: "
+                f"{response.text}"
+            )
+            _log.error(error_msg)
+            raise Exception(error_msg)
+
+    def call_service(self, domain, service, data):
+        """POST /api/services/{domain}/{service} with JSON data"""
+        url = f"{self.base_url}/api/services/{domain}/{service}"
+        try:
+            response = requests.post(url, headers=self.headers, json=data)
+            if response.status_code == 200:
+                _log.info(f"Success: {domain}/{service} for {data.get('entity_id', '')}")
+            else:
+                error_msg = (
+                    f"POST {url} failed with status {response.status_code}: "
+                    f"{response.text}"
+                )
+                _log.error(error_msg)
+                raise Exception(error_msg)
+        except requests.RequestException as e:
+            error_msg = f"Request error for {domain}/{service}: {e}"
+            _log.error(error_msg)
+            raise Exception(error_msg)

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/__init__.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/__init__.py
@@ -10,11 +10,13 @@ from .light_handler import LightHandler
 from .climate_handler import ClimateHandler
 from .generic_handler import GenericHandler
 from .fan_handler import FanHandler
+from .switch_handler import SwitchHandler
 
 __all__ = [
     "BaseHandler",
     "LightHandler",
     "ClimateHandler",
     "GenericHandler",
-    "FanHandler"
+    "FanHandler",
+    "SwitchHandler" 
 ]

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/__init__.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/__init__.py
@@ -9,10 +9,12 @@ from .base_handler import BaseHandler
 from .light_handler import LightHandler
 from .climate_handler import ClimateHandler
 from .generic_handler import GenericHandler
+from .fan_handler import FanHandler
 
 __all__ = [
     "BaseHandler",
     "LightHandler",
     "ClimateHandler",
-    "GenericHandler"
+    "GenericHandler",
+    "FanHandler"
 ]

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/__init__.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/__init__.py
@@ -1,0 +1,18 @@
+"""
+Handler module for Home Assistant interface.
+
+Provides device-specific handlers for processing write operations
+to different entity types in Home Assistant.
+"""
+
+from .base_handler import BaseHandler
+from .light_handler import LightHandler
+from .climate_handler import ClimateHandler
+from .generic_handler import GenericHandler
+
+__all__ = [
+    "BaseHandler",
+    "LightHandler",
+    "ClimateHandler",
+    "GenericHandler"
+]

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/base_handler.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/base_handler.py
@@ -2,7 +2,9 @@ class BaseHandler:
     """
     Base class for all domain handlers.
     """
-
-    def handle_write(self, interface, register, value):
+    def handle_write(self, api_client, register, value):
         raise NotImplementedError("Handler must implement handle_write()")
     
+    # Convert the value read from HA to Volttron format and return it
+    def handle_read(self, entity_data, register):
+        raise NotImplementedError("Handler must implement handle_read()")

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/base_handler.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/base_handler.py
@@ -1,0 +1,8 @@
+class BaseHandler:
+    """
+    Base class for all domain handlers.
+    """
+
+    def handle_write(self, interface, register, value):
+        raise NotImplementedError("Handler must implement handle_write()")
+    

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/climate_handler.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/climate_handler.py
@@ -3,6 +3,9 @@ from .base_handler import BaseHandler
 
 class ClimateHandler(BaseHandler):
 
+    # Reverse mapping for reading state back from HA to Volttron format
+    STATE_TO_INT = {"off": 0, "heat": 2, "cool": 3, "auto": 4}
+
     MODE_MAP = {
         0: "off",
         2: "heat",
@@ -10,26 +13,36 @@ class ClimateHandler(BaseHandler):
         4: "auto",
     }
 
-    def handle_write(self, interface, register, value):
-
+    def handle_write(self, api_client, register, value):
         entity_id = register.entity_id
         entity_point = register.entity_point
 
         if entity_point == "state":
-
             if value not in self.MODE_MAP:
                 raise ValueError("Climate state must be 0, 2, 3, or 4")
-
             mode = self.MODE_MAP[value]
-
-            interface.change_thermostat_mode(entity_id, mode)
+            api_client.call_service("climate", "set_hvac_mode", {
+                "entity_id": entity_id,
+                "hvac_mode": mode,
+            })
 
         elif entity_point == "temperature":
-
-            interface.set_thermostat_temperature(entity_id, value)
+            api_client.call_service("climate", "set_temperature", {
+                "entity_id": entity_id,
+                "temperature": value,
+            })
 
         else:
-            raise ValueError(
-                f"Unsupported climate attribute: {entity_point}"
-            )
-        
+            raise ValueError(f"Unsupported climate attribute: {entity_point}")
+
+    def handle_read(self, entity_data, register):
+        entity_point = register.entity_point
+
+        if entity_point == "state":
+            state = entity_data.get("state", None)
+            if state not in self.STATE_TO_INT:
+                raise ValueError(f"Unsupported climate state: {state}")
+            return self.STATE_TO_INT[state]
+        # Extensible to support other attributes in the future instead of hardcoding temperature and other attributes
+        else:
+            return entity_data.get("attributes", {}).get(entity_point, 0)  

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/climate_handler.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/climate_handler.py
@@ -1,0 +1,35 @@
+from .base_handler import BaseHandler
+
+
+class ClimateHandler(BaseHandler):
+
+    MODE_MAP = {
+        0: "off",
+        2: "heat",
+        3: "cool",
+        4: "auto",
+    }
+
+    def handle_write(self, interface, register, value):
+
+        entity_id = register.entity_id
+        entity_point = register.entity_point
+
+        if entity_point == "state":
+
+            if value not in self.MODE_MAP:
+                raise ValueError("Climate state must be 0, 2, 3, or 4")
+
+            mode = self.MODE_MAP[value]
+
+            interface.change_thermostat_mode(entity_id, mode)
+
+        elif entity_point == "temperature":
+
+            interface.set_thermostat_temperature(entity_id, value)
+
+        else:
+            raise ValueError(
+                f"Unsupported climate attribute: {entity_point}"
+            )
+        

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/fan_handler.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/fan_handler.py
@@ -1,0 +1,62 @@
+from .base_handler import BaseHandler
+
+
+class FanHandler(BaseHandler):
+
+    SPEED_TO_PERCENTAGE = {
+        1: 33,
+        2: 66,
+        3: 100,
+        "low": 33,
+        "medium": 66,
+        "high": 100,
+    }
+
+    def handle_write(self, api_client, register, value):
+        entity_id = register.entity_id
+        entity_point = register.entity_point
+
+        if entity_point == "state":
+            if value == 1:
+                api_client.call_service("fan", "turn_on", {"entity_id": entity_id})
+            elif value == 0:
+                api_client.call_service("fan", "turn_off", {"entity_id": entity_id})
+            else:
+                raise ValueError("Fan state must be 0 or 1")
+
+        elif entity_point == "speed":
+            if value not in self.SPEED_TO_PERCENTAGE:
+                raise ValueError("Fan speed must be one of: 1, 2, 3, low, medium, high")
+
+            api_client.call_service("fan", "set_percentage", {
+                "entity_id": entity_id,
+                "percentage": self.SPEED_TO_PERCENTAGE[value],
+            })
+
+        else:
+            raise ValueError(f"Unsupported fan attribute: {entity_point}")
+
+    def handle_read(self, entity_data, register):
+        entity_point = register.entity_point
+
+        if entity_point == "state":
+            state = entity_data.get("state", None)
+            return 1 if state == "on" else 0
+
+        if entity_point == "speed":
+            state = entity_data.get("state", None)
+            if state == "off":
+                return 0
+
+            percentage = entity_data.get("attributes", {}).get("percentage", None)
+            if percentage is None:
+                return 1
+            if percentage <= 0:
+                return 1
+            if percentage <= 33:
+                return 1
+            if percentage <= 66:
+                return 2
+            return 3
+
+        return entity_data.get("attributes", {}).get(entity_point, 0)

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/generic_handler.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/generic_handler.py
@@ -2,23 +2,27 @@ from .base_handler import BaseHandler
 
 
 class GenericHandler(BaseHandler):
-
-    def handle_write(self, interface, register, value):
-
+    
+    def handle_write(self, api_client, register, value):
         entity_id = register.entity_id
         entity_point = register.entity_point
 
         if entity_point != "state":
-            raise ValueError(
-                f"Generic handler only supports 'state', got {entity_point}"
-            )
+            raise ValueError(f"Generic handler only supports 'state', got {entity_point}")
 
         if value == 1:
-            interface.set_input_boolean(entity_id, "on")
-
+            api_client.call_service("input_boolean", "turn_on", {"entity_id": entity_id})
         elif value == 0:
-            interface.set_input_boolean(entity_id, "off")
-
+            api_client.call_service("input_boolean", "turn_off", {"entity_id": entity_id})
         else:
             raise ValueError("State must be 0 or 1")
-        
+    
+    def handle_read(self, entity_data, register):
+        entity_point = register.entity_point
+
+        if entity_point == "state":
+            state = entity_data.get("state", None)
+            return 1 if state == "on" else 0
+        # Extensible to support other attributes in the future instead of hardcoding state
+        else:
+            return entity_data.get("attributes", {}).get(entity_point, 0)

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/generic_handler.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/generic_handler.py
@@ -1,0 +1,24 @@
+from .base_handler import BaseHandler
+
+
+class GenericHandler(BaseHandler):
+
+    def handle_write(self, interface, register, value):
+
+        entity_id = register.entity_id
+        entity_point = register.entity_point
+
+        if entity_point != "state":
+            raise ValueError(
+                f"Generic handler only supports 'state', got {entity_point}"
+            )
+
+        if value == 1:
+            interface.set_input_boolean(entity_id, "on")
+
+        elif value == 0:
+            interface.set_input_boolean(entity_id, "off")
+
+        else:
+            raise ValueError("State must be 0 or 1")
+        

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/light_handler.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/light_handler.py
@@ -3,29 +3,38 @@ from .base_handler import BaseHandler
 
 class LightHandler(BaseHandler):
 
-    def handle_write(self, interface, register, value):
-
+    def handle_write(self, api_client, register, value):
         entity_id = register.entity_id
         entity_point = register.entity_point
 
         if entity_point == "state":
-
             if value == 1:
-                interface.turn_on_lights(entity_id)
-
+                api_client.call_service("light", "turn_on", {"entity_id": entity_id})
             elif value == 0:
-                interface.turn_off_lights(entity_id)
-
+                api_client.call_service("light", "turn_off", {"entity_id": entity_id})
             else:
                 raise ValueError("Light state must be 0 or 1")
 
         elif entity_point == "brightness":
-
             if not (0 <= value <= 255):
                 raise ValueError("Brightness must be between 0 and 255")
-
-            interface.change_brightness(entity_id, value)
+            api_client.call_service("light", "turn_on", {
+                "entity_id": entity_id,
+                "brightness": value,
+            })
 
         else:
             raise ValueError(f"Unsupported light attribute: {entity_point}")
+    
+    def handle_read(self, entity_data, register):
+        entity_point = register.entity_point
+
+        if entity_point == "state":
+            state = entity_data.get("state", None)
+            return 1 if state == "on" else 0
+        
+        # For brightness, we assume it's stored in the attributes of the entity data
+        # Extensible to support other attributes in the future instead of hardcoding brightness
+        else:
+            return entity_data.get("attributes", {}).get(entity_point, 0)
         

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/light_handler.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/light_handler.py
@@ -1,0 +1,31 @@
+from .base_handler import BaseHandler
+
+
+class LightHandler(BaseHandler):
+
+    def handle_write(self, interface, register, value):
+
+        entity_id = register.entity_id
+        entity_point = register.entity_point
+
+        if entity_point == "state":
+
+            if value == 1:
+                interface.turn_on_lights(entity_id)
+
+            elif value == 0:
+                interface.turn_off_lights(entity_id)
+
+            else:
+                raise ValueError("Light state must be 0 or 1")
+
+        elif entity_point == "brightness":
+
+            if not (0 <= value <= 255):
+                raise ValueError("Brightness must be between 0 and 255")
+
+            interface.change_brightness(entity_id, value)
+
+        else:
+            raise ValueError(f"Unsupported light attribute: {entity_point}")
+        

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/switch_handler.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/switch_handler.py
@@ -1,0 +1,28 @@
+from .base_handler import BaseHandler
+
+
+class SwitchHandler(BaseHandler):
+
+    def handle_write(self, api_client, register, value):
+        entity_id = register.entity_id
+        entity_point = register.entity_point
+
+        if entity_point == "state":
+            if value == 1:
+                api_client.call_service("switch", "turn_on", {"entity_id": entity_id})
+            elif value == 0:
+                api_client.call_service("switch", "turn_off", {"entity_id": entity_id})
+            else:
+                raise ValueError("Switch state must be 0 or 1")
+
+        else:
+            raise ValueError(f"Unsupported switch attribute: {entity_point}")
+
+    def handle_read(self, entity_data, register):
+        entity_point = register.entity_point
+
+        if entity_point == "state":
+            state = entity_data.get("state", None)
+            return 1 if state == "on" else 0
+
+        return entity_data.get("attributes", {}).get(entity_point, 0)

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
@@ -35,6 +35,7 @@ import requests
 from requests import get
 
 from .handlers import LightHandler, ClimateHandler, GenericHandler
+from .api_client import HomeAssistantAPIClient
 
 _log = logging.getLogger(__name__)
 type_mapping = {"string": str,
@@ -61,95 +62,60 @@ class HomeAssistantRegister(BaseRegister):
         self.entity_point = entity_point
 
 
-def _post_method(url, headers, data, operation_description):
-    err = None
-    try:
-        response = requests.post(url, headers=headers, json=data)
-        if response.status_code == 200:
-            _log.info(f"Success: {operation_description}")
-        else:
-            err = f"Failed to {operation_description}. Status code: {response.status_code}. " \
-                  f"Response: {response.text}"
-
-    except requests.RequestException as e:
-        err = f"Error when attempting - {operation_description} : {e}"
-    if err:
-        _log.error(err)
-        raise Exception(err)
-
-
 class Interface(BasicRevert, BaseInterface):
     def __init__(self, **kwargs):
         super(Interface, self).__init__(**kwargs)
-        self.point_name = None
-        self.ip_address = None
-        self.access_token = None
-        self.port = None
-        self.units = None
+        self.api_client = None
 
     def configure(self, config_dict, registry_config_str):
-        self.ip_address = config_dict.get("ip_address", None)
-        self.access_token = config_dict.get("access_token", None)
-        self.port = config_dict.get("port", None)
+        ip_address = config_dict.get("ip_address", None)
+        access_token = config_dict.get("access_token", None)
+        port = config_dict.get("port", None)
 
-        # Check for None values
-        if self.ip_address is None:
-            _log.error("IP address is not set.")
+        if ip_address is None:
             raise ValueError("IP address is required.")
-        if self.access_token is None:
-            _log.error("Access token is not set.")
+        if access_token is None:
             raise ValueError("Access token is required.")
-        if self.port is None:
-            _log.error("Port is not set.")
+        if port is None:
             raise ValueError("Port is required.")
 
+        self.api_client = HomeAssistantAPIClient(ip_address, port, access_token)
         self.parse_config(registry_config_str)
 
     def get_point(self, point_name):
         register = self.get_register_by_name(point_name)
+        entity_data = self.api_client.get_state(register.entity_id)
 
-        entity_data = self.get_entity_data(register.entity_id)
-        if register.point_name == "state":
-            result = entity_data.get("state", None)
-            return result
+        domain = register.entity_id.split(".")[0]
+        handler = service_mapping.get(domain, None)
+
+        if handler:
+            return handler.handle_read(entity_data, register)
         else:
-            value = entity_data.get("attributes", {}).get(f"{register.point_name}", 0)
-            return value
+            if register.entity_point == "state":
+                return entity_data.get("state", None)
+            else:
+                return entity_data.get("attributes", {}).get(register.entity_point, 0)
+
 
     def _set_point(self, point_name, value):
         register = self.get_register_by_name(point_name)
         if register.read_only:
-            raise IOError(
-                "Trying to write to a point configured read only: " + point_name)
-        register.value = register.reg_type(value)  # setting the value
+            raise IOError("Trying to write to a point configured read only: " + point_name)
+        register.value = register.reg_type(value)
 
-        # Get domain from entity_id to determine which handler to use.
         domain = register.entity_id.split(".")[0]
         handler = service_mapping.get(domain, None)
         if handler is None:
-            error_msg = f"No handler found for domain: {domain}. " \
-                        f"Currently supported domains are: {list(service_mapping.keys())}"
+            error_msg = (
+                f"No handler found for domain: {domain}. "
+                f"Supported domains: {list(service_mapping.keys())}"
+            )
             _log.error(error_msg)
             raise ValueError(error_msg)
-        handler.handle_write(self, register, value)
 
+        handler.handle_write(self.api_client, register, register.value)
         return register.value
-
-    def get_entity_data(self, point_name):
-        headers = {
-            "Authorization": f"Bearer {self.access_token}",
-            "Content-Type": "application/json",
-        }
-        # the /states grabs current state AND attributes of a specific entity
-        url = f"http://{self.ip_address}:{self.port}/api/states/{point_name}"
-        response = requests.get(url, headers=headers)
-        if response.status_code == 200:
-            return response.json()  # return the json attributes from entity
-        else:
-            error_msg = f"Request failed with status code {response.status_code}, Point name: {point_name}, " \
-                        f"response: {response.text}"
-            _log.error(error_msg)
-            raise Exception(error_msg)
 
     def _scrape_all(self):
         result = {}
@@ -158,62 +124,26 @@ class Interface(BasicRevert, BaseInterface):
 
         for register in read_registers + write_registers:
             entity_id = register.entity_id
-            entity_point = register.entity_point
             try:
-                entity_data = self.get_entity_data(entity_id)  # Using Entity ID to get data
-                if "climate." in entity_id:  # handling thermostats.
-                    if entity_point == "state":
-                        state = entity_data.get("state", None)
-                        # Giving thermostat states an equivalent number.
-                        if state == "off":
-                            register.value = 0
-                            result[register.point_name] = 0
-                        elif state == "heat":
-                            register.value = 2
-                            result[register.point_name] = 2
-                        elif state == "cool":
-                            register.value = 3
-                            result[register.point_name] = 3
-                        elif state == "auto":
-                            register.value = 4
-                            result[register.point_name] = 4
-                        else:
-                            error_msg = f"State {state} from {entity_id} is not yet supported"
-                            _log.error(error_msg)
-                            ValueError(error_msg)
-                    # Assigning attributes
-                    else:
-                        attribute = entity_data.get("attributes", {}).get(f"{entity_point}", 0)
-                        register.value = attribute
-                        result[register.point_name] = attribute
-                # handling light states
-                elif "light." or "input_boolean." in entity_id: # Checks for lights or input bools since they have the same states.
-                    if entity_point == "state":
-                        state = entity_data.get("state", None)
-                        # Converting light states to numbers.
-                        if state == "on":
-                            register.value = 1
-                            result[register.point_name] = 1
-                        elif state == "off":
-                            register.value = 0
-                            result[register.point_name] = 0
-                    else:
-                        attribute = entity_data.get("attributes", {}).get(f"{entity_point}", 0)
-                        register.value = attribute
-                        result[register.point_name] = attribute
-                else:  # handling all devices that are not thermostats or light states
-                    if entity_point == "state":
+                entity_data = self.api_client.get_state(entity_id)
+                domain = entity_id.split(".")[0]
+                handler = service_mapping.get(domain, None)
 
-                        state = entity_data.get("state", None)
-                        register.value = state
-                        result[register.point_name] = state
-                    # Assigning attributes
+                if handler:
+                    value = handler.handle_read(entity_data, register)
+                else:
+                    _log.debug(f"No handler for domain '{domain}', using raw value")
+                    if register.entity_point == "state":
+                        value = entity_data.get("state", None)
                     else:
-                        attribute = entity_data.get("attributes", {}).get(f"{entity_point}", 0)
-                        register.value = attribute
-                        result[register.point_name] = attribute
+                        value = entity_data.get("attributes", {}).get(
+                            register.entity_point, 0)
+
+                register.value = value
+                result[register.point_name] = value
+
             except Exception as e:
-                _log.error(f"An unexpected error occurred for entity_id: {entity_id}: {e}")
+                _log.error(f"Error for entity_id {entity_id}: {e}")
 
         return result
 
@@ -229,8 +159,8 @@ class Interface(BasicRevert, BaseInterface):
             read_only = str(regDef.get('Writable', '')).lower() != 'true'
             entity_id = regDef['Entity ID']
             entity_point = regDef['Entity Point']
-            self.point_name = regDef['Volttron Point Name']
-            self.units = regDef['Units']
+            point_name = regDef['Volttron Point Name']
+            units = regDef['Units']
             description = regDef.get('Notes', '')
             default_value = ("Starting Value")
             type_name = regDef.get("Type", 'string')
@@ -240,8 +170,8 @@ class Interface(BasicRevert, BaseInterface):
 
             register = register_type(
                 read_only,
-                self.point_name,
-                self.units,
+                point_name,
+                units,
                 reg_type,
                 attributes,
                 entity_id,
@@ -250,108 +180,6 @@ class Interface(BasicRevert, BaseInterface):
                 description=description)
 
             if default_value is not None:
-                self.set_default(self.point_name, register.value)
+                self.set_default(point_name, register.value)
 
             self.insert_register(register)
-
-    def turn_off_lights(self, entity_id):
-        url = f"http://{self.ip_address}:{self.port}/api/services/light/turn_off"
-        headers = {
-            "Authorization": f"Bearer {self.access_token}",
-            "Content-Type": "application/json",
-        }
-        payload = {
-            "entity_id": entity_id,
-        }
-        _post_method(url, headers, payload, f"turn off {entity_id}")
-
-    def turn_on_lights(self, entity_id):
-        url = f"http://{self.ip_address}:{self.port}/api/services/light/turn_on"
-        headers = {
-                "Authorization": f"Bearer {self.access_token}",
-                "Content-Type": "application/json",
-        }
-
-        payload = {
-            "entity_id": f"{entity_id}"
-        }
-        _post_method(url, headers, payload, f"turn on {entity_id}")
-
-    def change_thermostat_mode(self, entity_id, mode):
-        # Check if enttiy_id startswith climate.
-        if not entity_id.startswith("climate."):
-            _log.error(f"{entity_id} is not a valid thermostat entity ID.")
-            return
-        # Build header
-        url = f"http://{self.ip_address}:{self.port}/api/services/climate/set_hvac_mode"
-        headers = {
-                "Authorization": f"Bearer {self.access_token}",
-                "content-type": "application/json",
-        }
-        # Build data
-        data = {
-            "entity_id": entity_id,
-            "hvac_mode": mode,
-        }
-        # Post data
-        _post_method(url, headers, data, f"change mode of {entity_id} to {mode}")
-
-    def set_thermostat_temperature(self, entity_id, temperature):
-        # Check if the provided entity_id starts with "climate."
-        if not entity_id.startswith("climate."):
-            _log.error(f"{entity_id} is not a valid thermostat entity ID.")
-            return
-
-        url = f"http://{self.ip_address}:{self.port}/api/services/climate/set_temperature"
-        headers = {
-            "Authorization": f"Bearer {self.access_token}",
-            "content-type": "application/json",
-        }
-
-        if self.units == "C":
-            converted_temp = round((temperature - 32) * 5/9, 1)
-            _log.info(f"Converted temperature {converted_temp}")
-            data = {
-                "entity_id": entity_id,
-                "temperature": converted_temp,
-            }
-        else:
-            data = {
-                "entity_id": entity_id,
-                "temperature": temperature,
-            }
-        _post_method(url, headers, data, f"set temperature of {entity_id} to {temperature}")
-
-    def change_brightness(self, entity_id, value):
-        url = f"http://{self.ip_address}:{self.port}/api/services/light/turn_on"
-        headers = {
-                "Authorization": f"Bearer {self.access_token}",
-                "Content-Type": "application/json",
-        }
-        # ranges from 0 - 255
-        payload = {
-            "entity_id": f"{entity_id}",
-            "brightness": value,
-        }
-
-        _post_method(url, headers, payload, f"set brightness of {entity_id} to {value}")
-
-    def set_input_boolean(self, entity_id, state):
-        service = 'turn_on' if state == 'on' else 'turn_off'
-        url = f"http://{self.ip_address}:{self.port}/api/services/input_boolean/{service}"
-        headers = {
-            "Authorization": f"Bearer {self.access_token}",
-            "Content-Type": "application/json",
-        }
-
-        payload = {
-            "entity_id": entity_id
-        }
-
-        response = requests.post(url, headers=headers, json=payload)
-
-        # Optionally check for a successful response
-        if response.status_code == 200:
-            print(f"Successfully set {entity_id} to {state}")
-        else:
-            print(f"Failed to set {entity_id} to {state}: {response.text}")

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
@@ -34,7 +34,7 @@ import logging
 import requests
 from requests import get
 
-from .handlers import LightHandler, ClimateHandler, GenericHandler, FanHandler
+from .handlers import LightHandler, ClimateHandler, GenericHandler, FanHandler, SwitchHandler
 from .api_client import HomeAssistantAPIClient
 
 _log = logging.getLogger(__name__)
@@ -50,6 +50,7 @@ service_mapping= {
     "climate": ClimateHandler(),
     "input_boolean": GenericHandler(),
     "fan": FanHandler(),
+    "switch": SwitchHandler(),
 }
 
 class HomeAssistantRegister(BaseRegister):

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
@@ -34,6 +34,8 @@ import logging
 import requests
 from requests import get
 
+from .handlers import LightHandler, ClimateHandler, GenericHandler
+
 _log = logging.getLogger(__name__)
 type_mapping = {"string": str,
                 "int": int,
@@ -42,6 +44,11 @@ type_mapping = {"string": str,
                 "bool": bool,
                 "boolean": bool}
 
+service_mapping= {
+    "light": LightHandler(),
+    "climate": ClimateHandler(),
+    "input_boolean": GenericHandler(),
+}
 
 class HomeAssistantRegister(BaseRegister):
     def __init__(self, read_only, pointName, units, reg_type, attributes, entity_id, entity_point, default_value=None,
@@ -115,74 +122,17 @@ class Interface(BasicRevert, BaseInterface):
             raise IOError(
                 "Trying to write to a point configured read only: " + point_name)
         register.value = register.reg_type(value)  # setting the value
-        entity_point = register.entity_point
-        # Changing lights values in home assistant based off of register value.
-        if "light." in register.entity_id:
-            if entity_point == "state":
-                if isinstance(register.value, int) and register.value in [0, 1]:
-                    if register.value == 1:
-                        self.turn_on_lights(register.entity_id)
-                    elif register.value == 0:
-                        self.turn_off_lights(register.entity_id)
-                else:
-                    error_msg = f"State value for {register.entity_id} should be an integer value of 1 or 0"
-                    _log.info(error_msg)
-                    raise ValueError(error_msg)
 
-            elif entity_point == "brightness":
-                if isinstance(register.value, int) and 0 <= register.value <= 255:  # Make sure its int and within range
-                    self.change_brightness(register.entity_id, register.value)
-                else:
-                    error_msg = "Brightness value should be an integer between 0 and 255"
-                    _log.error(error_msg)
-                    raise ValueError(error_msg)
-            else:
-                error_msg = f"Unexpected point_name {point_name} for register {register.entity_id}"
-                _log.error(error_msg)
-                raise ValueError(error_msg)
-
-        elif "input_boolean." in register.entity_id:
-            if entity_point == "state":
-                if isinstance(register.value, int) and register.value in [0, 1]:
-                    if register.value == 1:
-                        self.set_input_boolean(register.entity_id, "on")
-                    elif register.value == 0:
-                        self.set_input_boolean(register.entity_id, "off")
-                else:
-                    error_msg = f"State value for {register.entity_id} should be an integer value of 1 or 0"
-                    _log.info(error_msg)
-                    raise ValueError(error_msg)
-            else:
-                _log.info(f"Currently, input_booleans only support state")
-
-        # Changing thermostat values.
-        elif "climate." in register.entity_id:
-            if entity_point == "state":
-                if isinstance(register.value, int) and register.value in [0, 2, 3, 4]:
-                    if register.value == 0:
-                        self.change_thermostat_mode(entity_id=register.entity_id, mode="off")
-                    elif register.value == 2:
-                        self.change_thermostat_mode(entity_id=register.entity_id, mode="heat")
-                    elif register.value == 3:
-                        self.change_thermostat_mode(entity_id=register.entity_id, mode="cool")
-                    elif register.value == 4:
-                        self.change_thermostat_mode(entity_id=register.entity_id, mode="auto")
-                else:
-                    error_msg = f"Climate state should be an integer value of 0, 2, 3, or 4"
-                    _log.error(error_msg)
-                    raise ValueError(error_msg)
-            elif entity_point == "temperature":
-                self.set_thermostat_temperature(entity_id=register.entity_id, temperature=register.value)
-
-            else:
-                error_msg = f"Currently set_point is supported only for thermostats state and temperature {register.entity_id}"
-                _log.error(error_msg)
-                raise ValueError(error_msg)
-        else:
-            error_msg = f"Unsupported entity_id: {register.entity_id}. " \
-                        f"Currently set_point is supported only for thermostats and lights"
+        # Get domain from entity_id to determine which handler to use.
+        domain = register.entity_id.split(".")[0]
+        handler = service_mapping.get(domain, None)
+        if handler is None:
+            error_msg = f"No handler found for domain: {domain}. " \
+                        f"Currently supported domains are: {list(service_mapping.keys())}"
             _log.error(error_msg)
             raise ValueError(error_msg)
+        handler.handle_write(self, register, value)
+
         return register.value
 
     def get_entity_data(self, point_name):

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py
@@ -34,7 +34,7 @@ import logging
 import requests
 from requests import get
 
-from .handlers import LightHandler, ClimateHandler, GenericHandler
+from .handlers import LightHandler, ClimateHandler, GenericHandler, FanHandler
 from .api_client import HomeAssistantAPIClient
 
 _log = logging.getLogger(__name__)
@@ -49,6 +49,7 @@ service_mapping= {
     "light": LightHandler(),
     "climate": ClimateHandler(),
     "input_boolean": GenericHandler(),
+    "fan": FanHandler(),
 }
 
 class HomeAssistantRegister(BaseRegister):

--- a/services/core/PlatformDriverAgent/tests/test_home_assistant.py
+++ b/services/core/PlatformDriverAgent/tests/test_home_assistant.py
@@ -26,6 +26,8 @@ import json
 import logging
 import pytest
 import gevent
+# import os for environment variables to avoid hardcoding in test file
+import os
 
 from volttron.platform.agent.known_identities import (
     PLATFORM_DRIVER,
@@ -41,9 +43,10 @@ logger = logging.getLogger(__name__)
 
 # To run these tests, create a helper toggle named volttrontest in your Home Assistant instance.
 # This can be done by going to Settings > Devices & services > Helpers > Create Helper > Toggle
-HOMEASSISTANT_TEST_IP = ""
-ACCESS_TOKEN = ""
-PORT = ""
+# Use os to set env for the IP address, access token, and port of your Home Assistant instance.
+HOMEASSISTANT_TEST_IP = os.getenv("HA_IP", "")
+ACCESS_TOKEN = os.getenv("HA_ACCESS_TOKEN", "")
+PORT = os.getenv("HA_PORT", "")
 
 skip_msg = "Some configuration variables are not set. Check HOMEASSISTANT_TEST_IP, ACCESS_TOKEN, and PORT"
 

--- a/services/core/PlatformDriverAgent/tests/test_home_assistant_fan_handler.py
+++ b/services/core/PlatformDriverAgent/tests/test_home_assistant_fan_handler.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*- {{ {
+# ===----------------------------------------------------------------------===
+#
+#                 Component of Eclipse VOLTTRON
+#
+# ===----------------------------------------------------------------------===
+#
+# Copyright 2023 Battelle Memorial Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# ===----------------------------------------------------------------------===
+# }}}
+
+from unittest.mock import Mock
+
+import pytest
+
+from platform_driver.interfaces.handlers.fan_handler import FanHandler
+
+
+class _Register:
+    def __init__(self, entity_id, entity_point):
+        self.entity_id = entity_id
+        self.entity_point = entity_point
+
+
+@pytest.fixture
+def fan_handler():
+    return FanHandler()
+
+
+@pytest.fixture
+def api_client():
+    return Mock()
+
+
+@pytest.mark.parametrize("value,service", [(1, "turn_on"), (0, "turn_off")])
+def test_handle_write_state_calls_expected_service(fan_handler, api_client, value, service):
+    register = _Register("fan.living_room", "state")
+
+    fan_handler.handle_write(api_client, register, value)
+
+    api_client.call_service.assert_called_once_with("fan", service, {"entity_id": "fan.living_room"})
+
+
+@pytest.mark.parametrize(
+    "value,percentage",
+    [
+        (1, 33),
+        (2, 66),
+        (3, 100),
+        ("low", 33),
+        ("medium", 66),
+        ("high", 100),
+    ],
+)
+def test_handle_write_speed_maps_to_percentage(fan_handler, api_client, value, percentage):
+    register = _Register("fan.living_room", "speed")
+
+    fan_handler.handle_write(api_client, register, value)
+
+    api_client.call_service.assert_called_once_with(
+        "fan",
+        "set_percentage",
+        {"entity_id": "fan.living_room", "percentage": percentage},
+    )
+
+
+@pytest.mark.parametrize("value", [2, -1, "on", "invalid", None])
+def test_handle_write_state_rejects_invalid_values(fan_handler, api_client, value):
+    register = _Register("fan.living_room", "state")
+
+    with pytest.raises(ValueError, match="Fan state must be 0 or 1"):
+        fan_handler.handle_write(api_client, register, value)
+
+
+@pytest.mark.parametrize("value", [0, 4, "max", "", None])
+def test_handle_write_speed_rejects_invalid_values(fan_handler, api_client, value):
+    register = _Register("fan.living_room", "speed")
+
+    with pytest.raises(ValueError, match="Fan speed must be one of"):
+        fan_handler.handle_write(api_client, register, value)
+
+
+def test_handle_write_rejects_unsupported_entity_point(fan_handler, api_client):
+    register = _Register("fan.living_room", "oscillation")
+
+    with pytest.raises(ValueError, match="Unsupported fan attribute"):
+        fan_handler.handle_write(api_client, register, 1)
+
+
+@pytest.mark.parametrize("state,expected", [("on", 1), ("off", 0), ("unknown", 0), (None, 0)])
+def test_handle_read_state_maps_to_int(fan_handler, state, expected):
+    register = _Register("fan.living_room", "state")
+    entity_data = {"state": state, "attributes": {}}
+
+    assert fan_handler.handle_read(entity_data, register) == expected
+
+
+@pytest.mark.parametrize(
+    "percentage,expected",
+    [
+        (0, 1),
+        (10, 1),
+        (33, 1),
+        (34, 2),
+        (66, 2),
+        (67, 3),
+        (100, 3),
+    ],
+)
+def test_handle_read_speed_maps_from_percentage(fan_handler, percentage, expected):
+    register = _Register("fan.living_room", "speed")
+    entity_data = {"state": "on", "attributes": {"percentage": percentage}}
+
+    assert fan_handler.handle_read(entity_data, register) == expected
+
+
+def test_handle_read_speed_defaults_to_low_when_percentage_missing(fan_handler):
+    register = _Register("fan.living_room", "speed")
+    entity_data = {"state": "on", "attributes": {}}
+
+    assert fan_handler.handle_read(entity_data, register) == 1
+
+
+def test_handle_read_speed_is_zero_when_fan_is_off(fan_handler):
+    register = _Register("fan.living_room", "speed")
+    entity_data = {"state": "off", "attributes": {}}
+
+    assert fan_handler.handle_read(entity_data, register) == 0
+
+
+def test_handle_read_fallback_to_attribute_value(fan_handler):
+    register = _Register("fan.living_room", "preset_mode")
+    entity_data = {"state": "on", "attributes": {"preset_mode": "eco"}}
+
+    assert fan_handler.handle_read(entity_data, register) == "eco"

--- a/services/core/PlatformDriverAgent/tests/test_home_assistant_switch_handler.py
+++ b/services/core/PlatformDriverAgent/tests/test_home_assistant_switch_handler.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*- {{{
+# ===----------------------------------------------------------------------===
+#
+# Component of Eclipse VOLTTRON
+#
+# ===----------------------------------------------------------------------===
+#
+# Copyright 2023 Battelle Memorial Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# ===----------------------------------------------------------------------===
+# }}}
+
+from unittest.mock import Mock
+
+import pytest
+
+from platform_driver.interfaces.handlers.switch_handler import SwitchHandler
+
+
+class _Register:
+    def __init__(self, entity_id, entity_point):
+        self.entity_id = entity_id
+        self.entity_point = entity_point
+
+
+@pytest.fixture
+def switch_handler():
+    return SwitchHandler()
+
+
+@pytest.fixture
+def api_client():
+    return Mock()
+
+
+@pytest.mark.parametrize("value,service", [(1, "turn_on"), (0, "turn_off")])
+def test_handle_write_state_calls_expected_service(switch_handler, api_client, value, service):
+    register = _Register("switch.living_room_outlet", "state")
+
+    switch_handler.handle_write(api_client, register, value)
+
+    api_client.call_service.assert_called_once_with("switch", service, {"entity_id": "switch.living_room_outlet"})
+
+
+@pytest.mark.parametrize("value", [2, -1, "on", "invalid", None])
+def test_handle_write_state_rejects_invalid_values(switch_handler, api_client, value):
+    register = _Register("switch.living_room_outlet", "state")
+
+    with pytest.raises(ValueError, match="Switch state must be 0 or 1"):
+        switch_handler.handle_write(api_client, register, value)
+
+
+def test_handle_write_rejects_unsupported_entity_point(switch_handler, api_client):
+    register = _Register("switch.living_room_outlet", "power_consumption")
+
+    with pytest.raises(ValueError, match="Unsupported switch attribute"):
+        switch_handler.handle_write(api_client, register, 1)
+
+
+@pytest.mark.parametrize("state,expected", [("on", 1), ("off", 0), ("unknown", 0), (None, 0)])
+def test_handle_read_state_maps_to_int(switch_handler, state, expected):
+    register = _Register("switch.living_room_outlet", "state")
+    entity_data = {"state": state, "attributes": {}}
+
+    assert switch_handler.handle_read(entity_data, register) == expected
+
+
+def test_handle_read_fallback_to_attribute_value(switch_handler):
+    register = _Register("switch.living_room_outlet", "friendly_name")
+    entity_data = {"state": "on", "attributes": {"friendly_name": "Living Room Outlet"}}
+
+    assert switch_handler.handle_read(entity_data, register) == "Living Room Outlet"


### PR DESCRIPTION
Closes https://github.com/kate-xke/volttron/issues/20

## Changes

1. Add [`switch_handler.py`](services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/switch_handler.py)
   - New `SwitchHandler(BaseHandler)` class
   - Write support: `0/1` → `switch.turn_off` / `switch.turn_on`
   - Read support: `"on"/"off"` → `1/0`
   - Raises `ValueError` for invalid state values or unsupported entity points

2. Update [`handlers/__init__.py`](services/core/PlatformDriverAgent/platform_driver/interfaces/handlers/__init__.py)
   - Import and export `SwitchHandler`

3. Update [`home_assistant.py`](services/core/PlatformDriverAgent/platform_driver/interfaces/home_assistant.py)
   - Add `SwitchHandler` to import
   - Register `"switch": SwitchHandler()` in `service_mapping`

4. Add [`test_home_assistant_switch_handler.py`](services/core/PlatformDriverAgent/tests/test_home_assistant_switch_handler.py)
   - 13 unit tests covering write, read, and error cases
   - Uses `Mock` for `api_client` — no live HA instance required

## Test Results
```
13 passed, 0 failed
```